### PR TITLE
[PLANG-987] Deprecate the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# go-crypto
+# [DEPRECATED] go-crypto
+Deprecated: We don't support this function and this library anymore, please use the `bitrise-io/bits` package at https://github.com/bitrise-io/bits
+
 Cryptographic algorithms for Go
 
 ### Available algorithms:

--- a/crypto/aes_256_gcm.go
+++ b/crypto/aes_256_gcm.go
@@ -8,12 +8,14 @@ import (
 )
 
 // AES256GCMCipher ...
+// Deprecated: We don't support this function and this library anymore, please use the `bitrise-io/bits` package at https://github.com/bitrise-io/bits
 func AES256GCMCipher(textToEncrypt string, iv []byte, encryptKey string) ([]byte, error) {
 	data := []byte(textToEncrypt)
 	return AES256GCMCipherBytesInput(data, iv, []byte(encryptKey))
 }
 
 // AES256GCMCipherBytesInput ...
+// Deprecated: We don't support this function and this library anymore, please use the `bitrise-io/bits` package at https://github.com/bitrise-io/bits
 func AES256GCMCipherBytesInput(data []byte, iv []byte, encryptKey []byte) ([]byte, error) {
 	block, err := aes.NewCipher(encryptKey)
 	if err != nil {
@@ -31,6 +33,7 @@ func AES256GCMCipherBytesInput(data []byte, iv []byte, encryptKey []byte) ([]byt
 }
 
 // AES256GCMDecipher ...
+// Deprecated: We don't support this function and this library anymore, please use the `bitrise-io/bits` package at https://github.com/bitrise-io/bits
 func AES256GCMDecipher(encryptedText, iv []byte, encryptKey string) (string, error) {
 	plaintext, err := AES256GCMDecipherByteOutput(encryptedText, iv, []byte(encryptKey))
 	if err != nil {
@@ -41,6 +44,7 @@ func AES256GCMDecipher(encryptedText, iv []byte, encryptKey string) (string, err
 }
 
 // AES256GCMDecipherByteOutput ...
+// Deprecated: We don't support this function and this library anymore, please use the `bitrise-io/bits` package at https://github.com/bitrise-io/bits
 func AES256GCMDecipherByteOutput(encryptedText, iv []byte, encryptKey []byte) ([]byte, error) {
 	block, err := aes.NewCipher(encryptKey)
 	if err != nil {

--- a/crypto/iv_generator.go
+++ b/crypto/iv_generator.go
@@ -3,6 +3,7 @@ package crypto
 import "github.com/pkg/errors"
 
 // GenerateIV ...
+// Deprecated: We don't support this function and this library anymore, please use the `bitrise-io/bits` package at https://github.com/bitrise-io/bits
 func GenerateIV() ([]byte, error) {
 	secureRandomBytes, err := SecureRandomBytes(12)
 	if err != nil {


### PR DESCRIPTION
Deprecate the package because we support these functionalities in the `bitrise-io/bits` package.